### PR TITLE
Javaスタンダード第23回SpringBoot例外処理を実装演習

### DIFF
--- a/src/main/java/reisetech/StudentManagement/StudentRepository/StudentRepository.java
+++ b/src/main/java/reisetech/StudentManagement/StudentRepository/StudentRepository.java
@@ -64,7 +64,7 @@ public interface StudentRepository {
   void updateStudent(Student student);
 
   /**
-   * 受講生コース情報のコース名を更新を行います。
+   * 受講生コース情報のコース名の更新を行います。
    *
    * @param studentCourse 受講生コース情報
    */

--- a/src/main/java/reisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/reisetech/StudentManagement/controller/StudentController.java
@@ -2,11 +2,12 @@ package reisetech.StudentManagement.controller;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import reisetech.StudentManagement.domain.StudentDetail;
+import reisetech.StudentManagement.exception.TestException;
 import reisetech.StudentManagement.service.StudentService;
 
 /**
@@ -79,5 +81,23 @@ public class StudentController {
   public ResponseEntity<String> updateStudent(@RequestBody @Valid StudentDetail studentDetail) {
     service.updateStudent(studentDetail);
     return ResponseEntity.ok("更新処理が成功しました。");
+  }
+
+  /**
+   * 受講生詳細一覧検索の例外を実装します。
+   *
+   * @throws TestException 　例外処理
+   * @return　エラーメッセージ
+   */
+
+  @GetMapping("/exceptionStudentList")
+  public List<StudentDetail> getTestStudentList() throws TestException {
+    throw new TestException(
+        "現在、このAPIは利用できません。URLは、「exceptionStudentList」ではなく、「studentList」を利用してください。");
+  }
+
+  @ExceptionHandler(TestException.class)
+  public ResponseEntity<String> handleTestException(TestException ex) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
   }
 }

--- a/src/main/java/reisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/reisetech/StudentManagement/controller/StudentController.java
@@ -4,10 +4,8 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,7 +13,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import reisetech.StudentManagement.domain.StudentDetail;
-import reisetech.StudentManagement.exception.TestException;
+import reisetech.StudentManagement.controller.exceptionHandler.exception.TestException;
 import reisetech.StudentManagement.service.StudentService;
 
 /**
@@ -91,13 +89,8 @@ public class StudentController {
    */
 
   @GetMapping("/exceptionStudentList")
-  public List<StudentDetail> getTestStudentList() throws TestException {
+  public List<StudentDetail> getExceptionStudentList() throws TestException {
     throw new TestException(
-        "現在、このAPIは利用できません。URLは、「exceptionStudentList」ではなく、「studentList」を利用してください。");
-  }
-
-  @ExceptionHandler(TestException.class)
-  public ResponseEntity<String> handleTestException(TestException ex) {
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+        "現在、このAPIは利用できません。URLは、「http://localhost:8080/exceptionStudentList」ではなく、「http://localhost:8080/studentList」を利用してください。");
   }
 }

--- a/src/main/java/reisetech/StudentManagement/controller/exceptionHandler/ExceptionHandlerClass.java
+++ b/src/main/java/reisetech/StudentManagement/controller/exceptionHandler/ExceptionHandlerClass.java
@@ -1,0 +1,16 @@
+package reisetech.StudentManagement.controller.exceptionHandler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import reisetech.StudentManagement.controller.exceptionHandler.exception.TestException;
+
+@ControllerAdvice
+public class ExceptionHandlerClass {
+
+  @ExceptionHandler(TestException.class)
+  public ResponseEntity<String> handleTestException(TestException ex) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+  }
+}

--- a/src/main/java/reisetech/StudentManagement/controller/exceptionHandler/exception/TestException.java
+++ b/src/main/java/reisetech/StudentManagement/controller/exceptionHandler/exception/TestException.java
@@ -1,4 +1,4 @@
-package reisetech.StudentManagement.exception;
+package reisetech.StudentManagement.controller.exceptionHandler.exception;
 
 public class TestException extends Exception {
 

--- a/src/main/java/reisetech/StudentManagement/exception/TestException.java
+++ b/src/main/java/reisetech/StudentManagement/exception/TestException.java
@@ -1,0 +1,20 @@
+package reisetech.StudentManagement.exception;
+
+public class TestException extends Exception {
+
+  public TestException() {
+    super();
+  }
+
+  public TestException(String message) {
+    super(message);
+  }
+
+  public TestException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public TestException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/resources/mapper/StudentRepository.xml
+++ b/src/main/resources/mapper/StudentRepository.xml
@@ -47,7 +47,7 @@
     WHERE id =#{id}
   </update>
 
-  <!--受講生コース情報のコース名を更新を行います。-->
+  <!--受講生コース情報のコース名の更新を行います。-->
   <update id="updateStudentCourse" parameterType="reisetech.StudentManagement.data.StudentCourse"
     statementType="PREPARED">
     UPDATE students_courses SET


### PR DESCRIPTION
StudentControllerに、exceptionStudentListというメソッドを追加し、エラーメッセージとして、「現在、このAPIは利用できません。URLは、「http://localhost:8080/exceptionStudentList」ではなく、「http://localhost:8080/studentList」を利用してください。」がPostmanへ出力されるような処理を行いました。

新たに、TestExceptionとExceptionHandlerClassというクラスを追加し、@ExceptionHandlerを利用して、エラーメッセージが出力されるように処理を実装しました。