### PR TITLE
Javaスタンダード第24回OpenAPI仕様書の演習

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     //Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    //Open API Generator
+    implementation'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
     providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/reisetech/StudentManagement/StudentManagementApplication.java
+++ b/src/main/java/reisetech/StudentManagement/StudentManagementApplication.java
@@ -1,9 +1,12 @@
 package reisetech.StudentManagement;
 
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+@OpenAPIDefinition(info = @Info(title = "受講生管理システム"))
 @SpringBootApplication
 
 public class StudentManagementApplication {

--- a/src/main/java/reisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/reisetech/StudentManagement/controller/StudentController.java
@@ -51,6 +51,7 @@ public class StudentController {
    * @return　受講生詳細(一件)
    */
 
+  @Operation(summary = "受講生詳細検索", description = "受講生IDに紐づく任意の受講生情報を検索します。※受講生IDは、整数値で入力してください。")
   @GetMapping("/student/{id}")
   public StudentDetail getStudent(@PathVariable @Pattern(regexp = "^\\d+$") String id) {
     return service.searchStudent(id);
@@ -63,7 +64,7 @@ public class StudentController {
    * @return　実行結果
    */
 
-  @Operation(summary = "受講生登録",description = "新規受講生を登録します。")
+  @Operation(summary = "受講生登録", description = "新規受講生を登録します。※受講生IDと受講生コースIDは、自動採番のため入力する必要はありません。")
   @PostMapping("/registerStudent")
   public ResponseEntity<StudentDetail> registerStudent(
       @RequestBody @Valid StudentDetail studentDetail) {
@@ -78,6 +79,7 @@ public class StudentController {
    * @return　実行結果
    */
 
+  @Operation(summary = "受講生詳細更新",description = "受講生詳細の更新を行います。※キャンセルフラグ(論理削除)の更新も行います。")
   @PutMapping("/updateStudent")
   public ResponseEntity<String> updateStudent(@RequestBody @Valid StudentDetail studentDetail) {
     service.updateStudent(studentDetail);
@@ -91,6 +93,7 @@ public class StudentController {
    * @return　エラーメッセージ
    */
 
+  @Operation(summary = "一覧検索の例外実装",description = "受講生一覧検索の例外が実装され、エラーメッセージが表示されます。")
   @GetMapping("/exceptionStudentList")
   public List<StudentDetail> getExceptionStudentList() throws TestException {
     throw new TestException(

--- a/src/main/java/reisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/reisetech/StudentManagement/controller/StudentController.java
@@ -1,5 +1,6 @@
 package reisetech.StudentManagement.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import java.util.List;
@@ -37,6 +38,7 @@ public class StudentController {
    * @return　受講生詳細一覧(全件)
    */
 
+  @Operation(summary = "一覧検索", description = "受講生の一覧を検索します。")
   @GetMapping("/studentList")
   public List<StudentDetail> getStudentList() {
     return service.searchStudentList();
@@ -61,6 +63,7 @@ public class StudentController {
    * @return　実行結果
    */
 
+  @Operation(summary = "受講生登録",description = "新規受講生を登録します。")
   @PostMapping("/registerStudent")
   public ResponseEntity<StudentDetail> registerStudent(
       @RequestBody @Valid StudentDetail studentDetail) {

--- a/src/main/java/reisetech/StudentManagement/data/Student.java
+++ b/src/main/java/reisetech/StudentManagement/data/Student.java
@@ -1,11 +1,13 @@
 package reisetech.StudentManagement.data;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
+@Schema(description = "受講生")
 @Getter
 @Setter
 public class Student {

--- a/src/main/java/reisetech/StudentManagement/data/StudentCourse.java
+++ b/src/main/java/reisetech/StudentManagement/data/StudentCourse.java
@@ -2,6 +2,7 @@ package reisetech.StudentManagement.data;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,7 +12,10 @@ import lombok.Setter;
 @Setter
 public class StudentCourse {
 
+  @Pattern(regexp = "^\\d+$")
   private String courseId;
+
+  @Pattern(regexp = "^\\d+$")
   private String studentId;
 
   @NotBlank

--- a/src/main/java/reisetech/StudentManagement/data/StudentCourse.java
+++ b/src/main/java/reisetech/StudentManagement/data/StudentCourse.java
@@ -1,10 +1,12 @@
 package reisetech.StudentManagement.data;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 
+@Schema(description = "受講生コース情報")
 @Getter
 @Setter
 public class StudentCourse {

--- a/src/main/java/reisetech/StudentManagement/domain/StudentDetail.java
+++ b/src/main/java/reisetech/StudentManagement/domain/StudentDetail.java
@@ -1,5 +1,6 @@
 package reisetech.StudentManagement.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.Setter;
 import reisetech.StudentManagement.data.Student;
 import reisetech.StudentManagement.data.StudentCourse;
 
+@Schema(description = "受講生詳細")
 @Getter
 @Setter
 @NoArgsConstructor


### PR DESCRIPTION
OpenAPIの導入するため、Open API Generatorを追加し、検索処理部分にOpenAPI仕様書に生成のためのコードを追加しました。

StudentCourse部分のStudentIdとcourseId部分に、数値のみの正規表現を追加しました。

更新・登録処理部分にもOpenAPI仕様書の導入に伴う情報の記述を行いました。