### PR TITLE
Javaスタンダード第29回Converterテスト実装

### DIFF
--- a/src/test/java/reisetech/StudentManagement/controller/converter/StudentConverterTest.java
+++ b/src/test/java/reisetech/StudentManagement/controller/converter/StudentConverterTest.java
@@ -23,12 +23,7 @@ class StudentConverterTest {
   void 受講生のリストと受講生コース情報のリストを渡して受講生詳細のリストが作成できること() {
     Student student = createStudent();
 
-    StudentCourse studentCourse = new StudentCourse();
-    studentCourse.setCourseId("1");
-    studentCourse.setStudentId("1");
-    studentCourse.setCourseName("Javaスタンダード");
-    studentCourse.setStartDate(LocalDateTime.now());
-    studentCourse.setEndDate(LocalDateTime.now().plusYears(1));
+    StudentCourse studentCourse = createStudentCourse("1");
 
     List<Student> studentList = List.of(student);
     List<StudentCourse> studentCourseList = List.of(studentCourse);
@@ -39,16 +34,12 @@ class StudentConverterTest {
     assertThat(actual.get(0).getStudentCourseList()).isEqualTo(studentCourseList);
   }
 
+
   @Test
   void 受講生のリストと受講生コース情報のリストを渡したときに受講生コース情報は除外されること() {
     Student student = createStudent();
 
-    StudentCourse studentCourse = new StudentCourse();
-    studentCourse.setCourseId("1");
-    studentCourse.setStudentId("2");
-    studentCourse.setCourseName("Javaスタンダード");
-    studentCourse.setStartDate(LocalDateTime.now());
-    studentCourse.setEndDate(LocalDateTime.now().plusYears(1));
+    StudentCourse studentCourse = createStudentCourse("2");
 
     List<Student> studentList = List.of(student);
     List<StudentCourse> studentCourseList = List.of(studentCourse);
@@ -59,10 +50,20 @@ class StudentConverterTest {
     assertThat(actual.get(0).getStudentCourseList()).isEmpty();
   }
 
-  private static Student createStudent() {
+  private Student createStudent() {
     Student student = new Student("1", "岩瀬杏瑠", "イワセアンル", "るた", "ruta@gmail.com",
         "愛知県安城市", 23, "女性", "", false);
 
     return student;
+  }
+
+  private StudentCourse createStudentCourse(String studentId) {
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setCourseId("1");
+    studentCourse.setStudentId(studentId);
+    studentCourse.setCourseName("Javaスタンダード");
+    studentCourse.setStartDate(LocalDateTime.now());
+    studentCourse.setEndDate(LocalDateTime.now().plusYears(1));
+    return studentCourse;
   }
 }

--- a/src/test/java/reisetech/StudentManagement/controller/converter/StudentConverterTest.java
+++ b/src/test/java/reisetech/StudentManagement/controller/converter/StudentConverterTest.java
@@ -1,0 +1,68 @@
+package reisetech.StudentManagement.controller.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reisetech.StudentManagement.data.Student;
+import reisetech.StudentManagement.data.StudentCourse;
+import reisetech.StudentManagement.domain.StudentDetail;
+
+class StudentConverterTest {
+
+  private StudentConverter sut;
+
+  @BeforeEach
+  void before() {
+    sut = new StudentConverter();
+  }
+
+  @Test
+  void 受講生のリストと受講生コース情報のリストを渡して受講生詳細のリストが作成できること() {
+    Student student = createStudent();
+
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setCourseId("1");
+    studentCourse.setStudentId("1");
+    studentCourse.setCourseName("Javaスタンダード");
+    studentCourse.setStartDate(LocalDateTime.now());
+    studentCourse.setEndDate(LocalDateTime.now().plusYears(1));
+
+    List<Student> studentList = List.of(student);
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+    List<StudentDetail> actual = sut.convertStudentDetails(studentList, studentCourseList);
+
+    assertThat(actual.get(0).getStudent()).isEqualTo(student);
+    assertThat(actual.get(0).getStudentCourseList()).isEqualTo(studentCourseList);
+  }
+
+  @Test
+  void 受講生のリストと受講生コース情報のリストを渡したときに受講生コース情報は除外されること() {
+    Student student = createStudent();
+
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setCourseId("1");
+    studentCourse.setStudentId("2");
+    studentCourse.setCourseName("Javaスタンダード");
+    studentCourse.setStartDate(LocalDateTime.now());
+    studentCourse.setEndDate(LocalDateTime.now().plusYears(1));
+
+    List<Student> studentList = List.of(student);
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+    List<StudentDetail> actual = sut.convertStudentDetails(studentList, studentCourseList);
+
+    assertThat(actual.get(0).getStudent()).isEqualTo(student);
+    assertThat(actual.get(0).getStudentCourseList()).isEmpty();
+  }
+
+  private static Student createStudent() {
+    Student student = new Student("1", "岩瀬杏瑠", "イワセアンル", "るた", "ruta@gmail.com",
+        "愛知県安城市", 23, "女性", "", false);
+
+    return student;
+  }
+}


### PR DESCRIPTION
studentConverterテストにて、createStudentの修飾子を消去しました。
また、StudentCourseをメソッド抽出で、createStudentCourseを作成しました。
![スクリーンショット (306)](https://github.com/user-attachments/assets/f57657f6-65ec-429a-957c-42b19b8d2413)
